### PR TITLE
Add abbreviation of replacement author name

### DIFF
--- a/midl.cls
+++ b/midl.cls
@@ -40,7 +40,7 @@
 \newcommand{\midlotherjointauthor}{\nametag{\addtocounter{footnote}{-1}\footnotemark}}
 
 \ifanonsubmission
- \newcommand{\midlauthor}[1]{\author{\Name{Author(s) names withheld} \Email{email(s) withheld} \\ \addr Address withheld}}
+ \newcommand{\midlauthor}[1]{\author{\Name[Author names withheld]{Author names withheld} \Email{email(s) withheld} \\ \addr Address withheld}}
  \newcommand{\midlacknowledgments}[1]{\acks{Acknowledgments withheld.}}
 \else
  \newcommand{\midlauthor}[1]{\author{\begin{NoHyper}#1\end{NoHyper}}}

--- a/midl.cls
+++ b/midl.cls
@@ -40,7 +40,7 @@
 \newcommand{\midlotherjointauthor}{\nametag{\addtocounter{footnote}{-1}\footnotemark}}
 
 \ifanonsubmission
- \newcommand{\midlauthor}[1]{\author{\Name[Author names withheld]{Author names withheld} \Email{email(s) withheld} \\ \addr Address withheld}}
+ \newcommand{\midlauthor}[1]{\author{\Name[Anonymous]{Author name(s) withheld} \Email{email(s) withheld} \\ \addr Address withheld}}
  \newcommand{\midlacknowledgments}[1]{\acks{Acknowledgments withheld.}}
 \else
  \newcommand{\midlauthor}[1]{\author{\begin{NoHyper}#1\end{NoHyper}}}


### PR DESCRIPTION
In "anon" mode, the value filled in as replacement of the actual author names is interpreted by the jrml class as the name of someone with initials "A. n." and last name "withheld". This looks ugly in the footer.