### PR TITLE
Fixing `\midlotherjointauthor`

### DIFF
--- a/midl.cls
+++ b/midl.cls
@@ -43,7 +43,7 @@
 \renewcommand\cite{\citep}
 
 \newcommand{\midljointauthortext}[1]{\nametag{\thanks{#1}}}
-\newcommand{\midlotherjointauthor}{\nametag{\addtocounter{footnote}{-1}\footnotemark}}
+\newcommand{\midlotherjointauthor}{\nametag{\footnotemark\addtocounter{footnote}{-1}}}
 
 \ifanonsubmission
  \newcommand{\midlauthor}[1]{\author{\Name[Anonymous]{Author name(s) withheld} \Email{email(s) withheld} \\ \addr Address withheld}}


### PR DESCRIPTION
When using `\midlotherjointauthor` on the second author to show equal contribution, the footnote mark was not showing properly. Moving `\addtocounter{footnote}{-1}` after `\footnotemark` in the definition of `\midlotherjointauthor` fixes issue #13.